### PR TITLE
Replace check_compile_time with __Check_Compile_Time

### DIFF
--- a/GBPing/ICMPHeader.h
+++ b/GBPing/ICMPHeader.h
@@ -33,17 +33,17 @@ struct IPHeader {
 };
 typedef struct IPHeader IPHeader;
 
-check_compile_time(sizeof(IPHeader) == 20);
-check_compile_time(offsetof(IPHeader, versionAndHeaderLength) == 0);
-check_compile_time(offsetof(IPHeader, differentiatedServices) == 1);
-check_compile_time(offsetof(IPHeader, totalLength) == 2);
-check_compile_time(offsetof(IPHeader, identification) == 4);
-check_compile_time(offsetof(IPHeader, flagsAndFragmentOffset) == 6);
-check_compile_time(offsetof(IPHeader, timeToLive) == 8);
-check_compile_time(offsetof(IPHeader, protocol) == 9);
-check_compile_time(offsetof(IPHeader, headerChecksum) == 10);
-check_compile_time(offsetof(IPHeader, sourceAddress) == 12);
-check_compile_time(offsetof(IPHeader, destinationAddress) == 16);
+__Check_Compile_Time(sizeof(IPHeader) == 20);
+__Check_Compile_Time(offsetof(IPHeader, versionAndHeaderLength) == 0);
+__Check_Compile_Time(offsetof(IPHeader, differentiatedServices) == 1);
+__Check_Compile_Time(offsetof(IPHeader, totalLength) == 2);
+__Check_Compile_Time(offsetof(IPHeader, identification) == 4);
+__Check_Compile_Time(offsetof(IPHeader, flagsAndFragmentOffset) == 6);
+__Check_Compile_Time(offsetof(IPHeader, timeToLive) == 8);
+__Check_Compile_Time(offsetof(IPHeader, protocol) == 9);
+__Check_Compile_Time(offsetof(IPHeader, headerChecksum) == 10);
+__Check_Compile_Time(offsetof(IPHeader, sourceAddress) == 12);
+__Check_Compile_Time(offsetof(IPHeader, destinationAddress) == 16);
 
 // ICMP type and code combinations:
 
@@ -69,12 +69,12 @@ struct ICMPHeader {
 };
 typedef struct ICMPHeader ICMPHeader;
 
-check_compile_time(sizeof(ICMPHeader) == 8);
-check_compile_time(offsetof(ICMPHeader, type) == 0);
-check_compile_time(offsetof(ICMPHeader, code) == 1);
-check_compile_time(offsetof(ICMPHeader, checksum) == 2);
-check_compile_time(offsetof(ICMPHeader, identifier) == 4);
-check_compile_time(offsetof(ICMPHeader, sequenceNumber) == 6);
+__Check_Compile_Time(sizeof(ICMPHeader) == 8);
+__Check_Compile_Time(offsetof(ICMPHeader, type) == 0);
+__Check_Compile_Time(offsetof(ICMPHeader, code) == 1);
+__Check_Compile_Time(offsetof(ICMPHeader, checksum) == 2);
+__Check_Compile_Time(offsetof(ICMPHeader, identifier) == 4);
+__Check_Compile_Time(offsetof(ICMPHeader, sequenceNumber) == 6);
 
 
 #endif


### PR DESCRIPTION
re #39.  AssertMacros.h has this to say about the ```check_compile_time``` macro:
```
 *	For time immemorial, Mac OS X has defined version of most of these macros without the __ prefix, which
 *	could collide with similarly named functions or macros in user code, including new functionality in
 *	Boost and the C++ standard library.
 *
 *  macOS High Sierra and iOS 11 will now require that clients move to the new macros as defined above.
```

This PR replaces ```check_compile_time``` with ```__Check_Compile_Time``` as required.