### PR TITLE
did remove crashing asserts

### DIFF
--- a/GBPing/GBPing.m
+++ b/GBPing/GBPing.m
@@ -497,9 +497,10 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
             case AF_INET6: {
                 packet = [self pingPacketWithType:kICMPv6TypeEchoRequest payload:payload requiresChecksum:NO];
             } break;
-            default: {
-                assert(NO);
-            } break;
+            default:
+                bytesSent = -1;
+                err = EINVAL;
+                return;
         }
         
         // this is our ping summary
@@ -764,7 +765,6 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen)
             result = [self isValidPing6ResponsePacket:packet];
         } break;
         default: {
-            assert(NO);
             result = NO;
         } break;
     }


### PR DESCRIPTION
In production we had too many crashes in sendPing function. Crashlytics shows crashes on 'assert()' put in sendPing function

There are two issues, I believe, related to those asserts: https://github.com/lmirosevic/GBPing/issues/36
https://github.com/lmirosevic/GBPing/issues/34