### PR TITLE
Removed asserts.

### DIFF
--- a/GBPing/GBPing.m
+++ b/GBPing/GBPing.m
@@ -364,7 +364,11 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
     enum { kBufferSize = 65535 };
     
     buffer = malloc(kBufferSize);
-    assert(buffer);
+
+    if (buffer == nil) {
+        err = errno;
+        return;
+    }
     
     //read the data.
     addrLen = sizeof(addr);
@@ -386,7 +390,11 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
             NSMutableData *packet;
 
             packet = [NSMutableData dataWithBytes:buffer length:(NSUInteger) bytesRead];
-            assert(packet);
+
+            if (packet == nil) {
+                err = errno;
+                return;
+            }
 
             //complete the ping summary
             const struct ICMPHeader *headerPointer;
@@ -503,7 +511,8 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
                 packet = [self pingPacketWithType:kICMPv6TypeEchoRequest payload:payload requiresChecksum:NO];
             } break;
             default: {
-                assert(NO);
+                err = errno;
+                return;
             } break;
         }
         
@@ -769,7 +778,6 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen)
             result = [self isValidPing6ResponsePacket:packet];
         } break;
         default: {
-            assert(NO);
             result = NO;
         } break;
     }
@@ -859,7 +867,7 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen)
     ICMPHeader *            icmpPtr;
     
     packet = [NSMutableData dataWithLength:sizeof(*icmpPtr) + payload.length];
-    assert(packet != nil);
+    if (packet == nil) { return nil; }
     
     icmpPtr = packet.mutableBytes;
     icmpPtr->type = type;


### PR DESCRIPTION
There are a couple of asserts with in seldom cases can produced crashes, as seen in our crash tool.

Those changes fix those crashes in our codebase