### PR TITLE
Support broadcast address ping responses

### DIFF
--- a/GBPing/GBPing.m
+++ b/GBPing/GBPing.m
@@ -385,7 +385,7 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
         inet_ntop(sin->sin_family, &(sin->sin_addr), hoststr, INET6_ADDRSTRLEN);
         NSString *host = [[NSString alloc] initWithUTF8String:hoststr];
 
-        if([host isEqualToString:self.hostAddressString]) { // only make sense where received packet comes from expected source
+        if([host isEqualToString:self.hostAddressString] || [self.hostAddressString hasSuffix:@".255"]) { // only make sense where received packet comes from expected source (or broadcast address)
             NSDate *receiveDate = [NSDate date];
             NSMutableData *packet;
 


### PR DESCRIPTION
## Summary

This PR restores support for broadcast ping responses in GBPing by modifying the source address check to allow .255 broadcast responses.

## Details

Support for broadcast pinging was originally introduced in [this commit](https://github.com/lmirosevic/GBPing/commit/4e968072aad164416ee0a5a741a49de38c95e9af). However, due to [this later change](https://github.com/lmirosevic/GBPing/blame/11fdcd17c70c1d0d91617fbfd3783e111a0628df/GBPing/GBPing.m#L382), responses from broadcast addresses were unintentionally filtered out.

This small fix adjusts the condition to also accept packets from broadcast addresses (i.e., hostnames ending in .255), ensuring that broadcast ping functionality works as intended again.